### PR TITLE
Use a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11  AS build-env
 
 ADD . /src
 WORKDIR /src
-RUN go install .
+RUN CGO_ENABLED=0 go install .
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:1.11
+FROM golang:1.11  AS build-env
 
 ADD . /src
 WORKDIR /src
 RUN go install .
 
-ENTRYPOINT ["/go/bin/aws_audit_exporter"]
+FROM scratch
 
+COPY --from=build-env /go/bin/aws_audit_exporter /
+ENTRYPOINT ["/aws_audit_exporter"]
 EXPOSE 9190

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/prometheus/client_golang v0.8.0
+	github.com/prometheus/client_golang v0.9.4
 	github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335 // indirect
 	github.com/prometheus/common v0.0.0-20170220103846-49fee292b27b // indirect
 	github.com/prometheus/procfs v0.0.0-20150223001136-6c34ef819e19 // indirect


### PR DESCRIPTION
Use a multi-stage build since the running container doesn't need all the go libs. 

It uses the scratch container to run the app and brings the container down to around 10meg