### PR TITLE
Needs the CA file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN CGO_ENABLED=0 go install .
 FROM scratch
 
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build-env /go/bin/aws_audit_exporter /]
+COPY --from=build-env /go/bin/aws_audit_exporter /
 ENTRYPOINT ["/aws_audit_exporter"]
 EXPOSE 9190

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN CGO_ENABLED=0 go install .
 
 FROM scratch
 
-COPY --from=build-env /go/bin/aws_audit_exporter /
+COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build-env /go/bin/aws_audit_exporter /]
 ENTRYPOINT ["/aws_audit_exporter"]
 EXPOSE 9190


### PR DESCRIPTION
I forgot to add the CA file into the scratch container. The request to the ec2 API endpoint will fail due to SSL errors without this